### PR TITLE
Update Standalone regex to match new URL scheme

### DIFF
--- a/Office2016-IndividualApps/MSOffice2016URLandUpdateInfoProvider.py
+++ b/Office2016-IndividualApps/MSOffice2016URLandUpdateInfoProvider.py
@@ -220,9 +220,10 @@ class MSOffice2016URLandUpdateInfoProvider(Processor):
         item = item[0]
         
         if self.env["type"] == "Standalone":
-            p = re.compile(ur'^[a-zA-Z0-9:/.-]*_[a-zA-Z]*')
+            p = re.compile(ur'(^[a-zA-Z0-9:/.-]*_[a-zA-Z]*_)(.*)Updater.pkg')
             url = item["Location"]
-            item["Location"] = re.search(p, url).group() + "_2016_Installer.pkg"
+            (firstGroup, secondGroup) = re.search(p, url).group(1, 2)
+            item["Location"] = firstGroup + "2016_"+ secondGroup + "Installer.pkg"
 
         self.env["url"] = item["Location"]
         self.output("Found URL %s" % self.env["url"])


### PR DESCRIPTION
Thanks to @clburlison !
### Slack Discussion for context:

@ftiff it seems like my regex doesn't work because `http://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/Microsoft_Word_2016_Installer.pkg` is in fact 15.19.1
@clburlison Right they changed the file name in 15.20(?) or 21.
@clburlison It's now `Microsoft_Word_2016_15.21.1_160411_Installer.pkg`
